### PR TITLE
feat: add coordination.k8s.io api group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,18 @@ resource "kubernetes_role" "this" {
     ]
   }
   rule {
+    api_groups = ["coordination.k8s.io"]
+    resources  = ["leases"]
+    verbs = [
+      "create",
+      "delete",
+      "get",
+      "list",
+      "patch",
+      "update",
+    ]
+  }
+  rule {
     api_groups = ["image.openshift.io"]
     resources  = ["imagestreamtags"]
     verbs      = ["delete"]


### PR DESCRIPTION
We have a scenario to `lock shared resources` and coordinate activity between members of a set such as `storing Terraform state in k8s secrets`.
- See https://kubernetes.io/docs/concepts/architecture/leases/